### PR TITLE
Allow translations to be saved on windows

### DIFF
--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -36,7 +36,7 @@ class File extends Translation implements DriverInterface
         $directories = Collection::make($this->disk->directories($this->languageFilesPath));
 
         return $directories->mapWithKeys(function ($directory) {
-            $language = array_last(explode('/', $directory));
+            $language = basename($directory);
 
             return [$language => $language];
         })->filter(function ($language) {


### PR DESCRIPTION
Replace `explode` with `basename` for compatibility with windows.

Fixes #21