### PR TITLE
Remove unused classes from tests

### DIFF
--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -4,7 +4,6 @@ namespace JoeDixon\Translation\Tests;
 
 use Orchestra\Testbench\TestCase;
 use JoeDixon\Translation\Language;
-use JoeDixon\Translation\Drivers\Database;
 use JoeDixon\Translation\Drivers\Translation;
 use JoeDixon\Translation\TranslationServiceProvider;
 use Illuminate\Foundation\Testing\DatabaseMigrations;

--- a/tests/FileDriverTest.php
+++ b/tests/FileDriverTest.php
@@ -3,7 +3,6 @@
 namespace JoeDixon\Translation\Tests;
 
 use Orchestra\Testbench\TestCase;
-use JoeDixon\Translation\Drivers\File;
 use JoeDixon\Translation\Drivers\Translation;
 use JoeDixon\Translation\Exceptions\LanguageExistsException;
 

--- a/tests/fixtures/lang/en/test.php
+++ b/tests/fixtures/lang/en/test.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+return array (
   'hello' => 'Hello',
   'whats_up' => 'What\'s up!',
-];
+);


### PR DESCRIPTION
Hey @joedixon. Really cool package!

This PR cleans two use declarations that are never used, on two different test classes, and updates an array to use the short array syntax instead of the `array()`.