### PR TITLE
Add arguments to sync command

### DIFF
--- a/src/Console/Commands/SynchroniseTranslationsCommand.php
+++ b/src/Console/Commands/SynchroniseTranslationsCommand.php
@@ -95,7 +95,7 @@ class SynchroniseTranslationsCommand extends Command
         $this->fromDriver = $this->createDriver($this->fromDriver);
 
         // When the to driver has been specified.
-        if ($this->argument('to')) {
+        if ($this->argument('to') && in_array($this->argument('to'), $this->drivers)) {
             $this->toDriver = $this->argument('to');
         }
 


### PR DESCRIPTION
As I don't want my client to run artisan commands by hand, I needed some arguments for the sync-translation command. 

This accepts optional arguments: 

- from - file | database
- to - file | database
- language - all | en | nl | etc.. 

Now you can run the command like:
```
translation:sync-translations database file all
```

When an argument is not set, or is invalid, the default anticipate() will ask for valid input.

If you're ok with it I would also like to make a Nova action for syncing the translations. I think the info outputs should be muted in order to get a valid response for Nova.