### PR TITLE
Added simple multidimentional array support.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,12 +16,10 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory>./src/Console</directory>
+            </exclude>
         </whitelist>
-    </filter>
-    <filter>
-        <blacklist>
-              <directory>./src/Console</directory>
-        </blacklist>
     </filter>
     <php>
         <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>

--- a/resources/helpers.php
+++ b/resources/helpers.php
@@ -48,6 +48,7 @@ if (! function_exists('array_diff_assoc_recursive')) {
      */
     function array_diff_assoc_recursive($arrayOne, $arrayTwo)
     {
+        $difference = [];
         foreach ($arrayOne as $key => $value) {
             if (is_array($value) || $value instanceof Illuminate\Support\Collection) {
                 if (! isset($arrayTwo[$key])) {
@@ -65,7 +66,7 @@ if (! function_exists('array_diff_assoc_recursive')) {
             }
         }
 
-        return ! isset($difference) ? [] : $difference;
+        return $difference;
     }
 }
 
@@ -80,5 +81,24 @@ if (! function_exists('str_before')) {
     function str_before($subject, $search)
     {
         return $search === '' ? $subject : explode($search, $subject)[0];
+    }
+}
+
+// Array undot
+if (!function_exists("array_undot")) {
+    /**
+     * Expands a single level array with dot notation into a multi-dimensional array
+     *
+     * @param array $dotNotationArray
+     *
+     * @return array
+     */
+    function array_undot(array $dotNotationArray)
+    {
+        $array = [];
+        foreach ($dotNotationArray as $key => $value) {
+            array_set($array, $key, $value);
+        }
+        return $array;
     }
 }

--- a/resources/helpers.php
+++ b/resources/helpers.php
@@ -87,7 +87,7 @@ if (! function_exists('str_before')) {
 // Array undot
 if (! function_exists('array_undot')) {
     /**
-     * Expands a single level array with dot notation into a multi-dimensional array
+     * Expands a single level array with dot notation into a multi-dimensional array.
      *
      * @param array $dotNotationArray
      *
@@ -99,6 +99,7 @@ if (! function_exists('array_undot')) {
         foreach ($dotNotationArray as $key => $value) {
             array_set($array, $key, $value);
         }
+
         return $array;
     }
 }

--- a/resources/helpers.php
+++ b/resources/helpers.php
@@ -85,7 +85,7 @@ if (! function_exists('str_before')) {
 }
 
 // Array undot
-if (!function_exists("array_undot")) {
+if (! function_exists('array_undot')) {
     /**
      * Expands a single level array with dot notation into a multi-dimensional array
      *

--- a/src/Console/Commands/AddTranslationKeyCommand.php
+++ b/src/Console/Commands/AddTranslationKeyCommand.php
@@ -51,7 +51,7 @@ class AddTranslationKeyCommand extends BaseCommand
         } elseif ($type === 'group') {
             try {
                 $file = str_replace('.php', '', $file);
-                $this->translation->addGroupTranslation($language, "{$file}.{$key}", $value);
+                $this->translation->addGroupTranslation($language, $file, $key, $value);
 
                 return $this->info(__('translation::translation.language_key_added'));
             } catch (\Exception $e) {

--- a/src/Console/Commands/SynchroniseTranslationsCommand.php
+++ b/src/Console/Commands/SynchroniseTranslationsCommand.php
@@ -125,7 +125,7 @@ class SynchroniseTranslationsCommand extends Command
                 if (is_array($value)) {
                     continue;
                 }
-                $driver->addGroupTranslation($language, "{$group}.{$key}", $value);
+                $driver->addGroupTranslation($language, $group, $key, $value);
             }
         }
     }

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -97,13 +97,11 @@ class Database extends Translation implements DriverInterface
      * @param string $value
      * @return void
      */
-    public function addGroupTranslation($language, $key, $value = '')
+    public function addGroupTranslation($language, $group, $key, $value = '')
     {
         if (! $this->languageExists($language)) {
             $this->addLanguage($language);
         }
-
-        list($group, $key) = explode('.', $key);
 
         Language::where('language', $language)
             ->first()

--- a/src/Drivers/DriverInterface.php
+++ b/src/Drivers/DriverInterface.php
@@ -49,7 +49,7 @@ interface DriverInterface
      * @param string $value
      * @return void
      */
-    public function addGroupTranslation($language, $key, $value = '');
+    public function addGroupTranslation($language, $group, $key, $value = '');
 
     /**
      * Add a new single type translation.

--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -219,7 +219,7 @@ class File extends Translation implements DriverInterface
         if ($this->disk->exists($filePath)) {
             $translations = Arr::dot($this->disk->getRequire($filePath));
         }
-        
+
         return $translations;
     }
 
@@ -247,21 +247,6 @@ class File extends Translation implements DriverInterface
     }
 
     /**
-     * Transform array with dot notation to multidiemsional array.
-     *
-     * @param array $dotNotationArray
-     * @return array
-     */
-    private function arrayUndot(array $dotNotationArray)
-    {
-        $array = [];
-        foreach ($dotNotationArray as $key => $value) {
-            array_set($array, $key, $value);
-        }
-        return $array;
-    }
-    
-    /**
      * Save group type language translations.
      *
      * @param string $language
@@ -275,7 +260,7 @@ class File extends Translation implements DriverInterface
         // different path
         $translations = $translations instanceof Collection ? $translations->toArray() : $translations;
         ksort($translations);
-        $translations = $this->arrayUndot($translations);
+        $translations = array_undot($translations);
         if (str_contains($group, '::')) {
             return $this->saveNamespacedGroupTranslations($language, $group, $translations);
         }

--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -2,6 +2,7 @@
 
 namespace JoeDixon\Translation\Drivers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
 use JoeDixon\Translation\Exceptions\LanguageExistsException;
@@ -117,13 +118,12 @@ class File extends Translation implements DriverInterface
      * @param string $value
      * @return void
      */
-    public function addGroupTranslation($language, $key, $value = '')
+    public function addGroupTranslation($language, $group, $key, $value = '')
     {
         if (! $this->languageExists($language)) {
             $this->addLanguage($language);
         }
 
-        list($group, $key) = explode('.', $key);
         $translations = $this->getGroupTranslationsFor($language);
 
         // does the group exist? If not, create it.
@@ -196,10 +196,10 @@ class File extends Translation implements DriverInterface
             if (str_contains($group->getPathname(), 'vendor')) {
                 $vendor = str_before(str_after($group->getPathname(), 'vendor/'), '/');
 
-                return ["{$vendor}::{$group->getBasename('.php')}" => new Collection($this->disk->getRequire($group->getPathname()))];
+                return ["{$vendor}::{$group->getBasename('.php')}" => new Collection(Arr::dot($this->disk->getRequire($group->getPathname())))];
             }
 
-            return [$group->getBasename('.php') => new Collection($this->disk->getRequire($group->getPathname()))];
+            return [$group->getBasename('.php') => new Collection(Arr::dot($this->disk->getRequire($group->getPathname())))];
         });
     }
 
@@ -217,10 +217,10 @@ class File extends Translation implements DriverInterface
         $translations = [];
 
         if ($this->disk->exists($filePath)) {
-            return $this->disk->getRequire($filePath);
+            $translations = Arr::dot($this->disk->getRequire($filePath));
         }
-
-        return [];
+        
+        return $translations;
     }
 
     /**
@@ -247,6 +247,21 @@ class File extends Translation implements DriverInterface
     }
 
     /**
+     * Transform array with dot notation to multidiemsional array.
+     *
+     * @param array $dotNotationArray
+     * @return array
+     */
+    private function arrayUndot(array $dotNotationArray)
+    {
+        $array = [];
+        foreach ($dotNotationArray as $key => $value) {
+            array_set($array, $key, $value);
+        }
+        return $array;
+    }
+    
+    /**
      * Save group type language translations.
      *
      * @param string $language
@@ -259,6 +274,8 @@ class File extends Translation implements DriverInterface
         // here we check if it's a namespaced translation which need saving to a
         // different path
         $translations = $translations instanceof Collection ? $translations->toArray() : $translations;
+        ksort($translations);
+        $translations = $this->arrayUndot($translations);
         if (str_contains($group, '::')) {
             return $this->saveNamespacedGroupTranslations($language, $group, $translations);
         }

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -39,7 +39,7 @@ abstract class Translation
                         if (str_contains($group, 'single')) {
                             $this->addSingleTranslation($language, $group, $key);
                         } else {
-                            $this->addGroupTranslation($language, "{$group}.{$key}");
+                            $this->addGroupTranslation($language, $group, $key);
                         }
                     }
                 }

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -53,7 +53,7 @@ class LanguageTranslationController extends Controller
     {
         if ($request->filled('group')) {
             $namespace = $request->has('namespace') && $request->get('namespace') ? "{$request->get('namespace')}::" : '';
-            $this->translation->addGroupTranslation($language, "{$namespace}{$request->get('group')}.{$request->get('key')}", $request->get('value') ?: '');
+            $this->translation->addGroupTranslation($language, "{$namespace}{$request->get('group')}", $request->get('key'), $request->get('value') ?: '');
         } else {
             $this->translation->addSingleTranslation($language, 'single', $request->get('key'), $request->get('value') ?: '');
         }
@@ -66,7 +66,7 @@ class LanguageTranslationController extends Controller
     public function update(Request $request, $language)
     {
         if (! str_contains($request->get('group'), 'single')) {
-            $this->translation->addGroupTranslation($language, "{$request->get('group')}.{$request->get('key')}", $request->get('value') ?: '');
+            $this->translation->addGroupTranslation($language, $request->get('group'), $request->get('key'), $request->get('value') ?: '');
         } else {
             $this->translation->addSingleTranslation($language, $request->get('group'), $request->get('key'), $request->get('value') ?: '');
         }

--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -126,7 +126,7 @@ class DatabaseDriverTest extends TestCase
     {
         $translation = factory(TranslationModel::class)->create();
 
-        $this->translation->addGroupTranslation($translation->language->language, "{$translation->group}", "test", "Testing');
+        $this->translation->addGroupTranslation($translation->language->language, "{$translation->group}", 'test', 'Testing');
 
         $translations = $this->translation->allTranslationsFor($translation->language->language);
 

--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -219,6 +219,33 @@ class DatabaseDriverTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_a_nested_translation()
+    {
+        $this->translation->addGroupTranslation('en', 'test', 'test.nested', 'Nested!');
+
+        $this->assertEquals($this->translation->getGroupTranslationsFor('en')->toArray(), [
+            'test' => [
+                'test.nested' => 'Nested!'
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_add_nested_vendor_namespaced_translations()
+    {
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'nested.hello', 'Hola!');
+
+        $this->assertEquals($this->translation->allTranslationsFor('es')->toArray(), [
+            'group' => [
+                'translation_test::test' => [
+                    'nested.hello' => 'Hola!',
+                ],
+            ],
+            'single' => [],
+        ]);
+    }
+
+    /** @test */
     public function it_can_merge_a_namespaced_language_with_the_base_language()
     {
         $this->translation->addGroupTranslation('en', 'translation_test::test', 'hello', 'Hello');

--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -114,7 +114,7 @@ class DatabaseDriverTest extends TestCase
     /** @test */
     public function it_can_add_a_new_translation_to_a_new_group()
     {
-        $this->translation->addGroupTranslation('es', 'test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'test', 'hello', 'Hola!');
 
         $translations = $this->translation->allTranslationsFor('es');
 
@@ -126,7 +126,7 @@ class DatabaseDriverTest extends TestCase
     {
         $translation = factory(TranslationModel::class)->create();
 
-        $this->translation->addGroupTranslation($translation->language->language, "{$translation->group}.test", 'Testing');
+        $this->translation->addGroupTranslation($translation->language->language, "{$translation->group}", "test", "Testing');
 
         $translations = $this->translation->allTranslationsFor($translation->language->language);
 
@@ -178,7 +178,7 @@ class DatabaseDriverTest extends TestCase
         factory(TranslationModel::class)->states('single')->create(['language_id' => $default->id, 'group' => 'single', 'key' => 'Hello', 'value' => 'Hello']);
         factory(TranslationModel::class)->states('single')->create(['language_id' => $default->id, 'group' => 'single', 'key' => "What's up", 'value' => "What's up!"]);
 
-        $this->translation->addGroupTranslation('es', 'test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'test', 'hello', 'Hola!');
         $translations = $this->translation->getSourceLanguageTranslationsWith('es');
 
         $this->assertEquals($translations->toArray(), [
@@ -206,7 +206,7 @@ class DatabaseDriverTest extends TestCase
     /** @test */
     public function it_can_add_a_vendor_namespaced_translations()
     {
-        $this->translation->addGroupTranslation('es', 'translation_test::test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'hello', 'Hola!');
 
         $this->assertEquals($this->translation->allTranslationsFor('es')->toArray(), [
             'group' => [
@@ -221,8 +221,8 @@ class DatabaseDriverTest extends TestCase
     /** @test */
     public function it_can_merge_a_namespaced_language_with_the_base_language()
     {
-        $this->translation->addGroupTranslation('en', 'translation_test::test.hello', 'Hello');
-        $this->translation->addGroupTranslation('es', 'translation_test::test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('en', 'translation_test::test', 'hello', 'Hello');
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'hello', 'Hola!');
         $translations = $this->translation->getSourceLanguageTranslationsWith('es');
 
         $this->assertEquals($translations->toArray(), [
@@ -250,7 +250,7 @@ class DatabaseDriverTest extends TestCase
     /** @test */
     public function the_language_creation_page_can_be_viewed()
     {
-        $this->translation->addGroupTranslation(config('app.locale'), 'translation::translation.add_language', 'Add a new language');
+        $this->translation->addGroupTranslation(config('app.locale'), 'translation::translation', 'add_language', 'Add a new language');
         $this->get(config('translation.ui_url').'/create')
             ->assertSee('Add a new language');
     }

--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -225,7 +225,7 @@ class DatabaseDriverTest extends TestCase
 
         $this->assertEquals($this->translation->getGroupTranslationsFor('en')->toArray(), [
             'test' => [
-                'test.nested' => 'Nested!'
+                'test.nested' => 'Nested!',
             ],
         ]);
     }

--- a/tests/DatabaseDriverTest.php
+++ b/tests/DatabaseDriverTest.php
@@ -283,7 +283,7 @@ class DatabaseDriverTest extends TestCase
     /** @test */
     public function the_translation_creation_page_can_be_viewed()
     {
-        $this->translation->addGroupTranslation('en', 'translation::translation.add_translation', 'Add a translation');
+        $this->translation->addGroupTranslation('en', 'translation::translation', 'add_translation', 'Add a translation');
         $this->get(config('translation.ui_url').'/'.config('app.locale').'/translations/create')
             ->assertSee('Add a translation');
     }

--- a/tests/FileDriverTest.php
+++ b/tests/FileDriverTest.php
@@ -189,6 +189,42 @@ class FileDriverTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_a_nested_translation()
+    {
+        $this->translation->addGroupTranslation('en', 'test', 'test.nested', 'Nested!');
+
+        $this->assertEquals($this->translation->getGroupTranslationsFor('en')->toArray(), [
+            'test' => [
+                'hello' => 'Hello',
+                'test.nested' => 'Nested!',
+                'whats_up' => 'What\'s up!',
+            ],
+        ]);
+
+        file_put_contents(
+            app()['path.lang'].'/en/test.php',
+            "<?php\n\nreturn ".var_export(['hello' => 'Hello', 'whats_up' => 'What\'s up!'], true).';'.\PHP_EOL
+        );
+    }
+
+    /** @test */
+    public function it_can_add_nested_vendor_namespaced_translations()
+    {
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'nested.hello', 'Hola!');
+
+        $this->assertEquals($this->translation->allTranslationsFor('es')->toArray(), [
+            'group' => [
+                'translation_test::test' => [
+                    'nested.hello' => 'Hola!',
+                ],
+            ],
+            'single' => [],
+        ]);
+
+        \File::deleteDirectory(__DIR__.'/fixtures/lang/vendor');
+    }
+
+    /** @test */
     public function it_can_merge_a_namespaced_language_with_the_base_language()
     {
         $this->translation->addGroupTranslation('en', 'translation_test::test', 'hello', 'Hello');

--- a/tests/FileDriverTest.php
+++ b/tests/FileDriverTest.php
@@ -82,7 +82,7 @@ class FileDriverTest extends TestCase
     /** @test */
     public function it_can_add_a_new_translation_to_a_new_group()
     {
-        $this->translation->addGroupTranslation('es', 'test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'test', 'hello', 'Hola!');
 
         $translations = $this->translation->allTranslationsFor('es');
 
@@ -94,7 +94,7 @@ class FileDriverTest extends TestCase
     /** @test */
     public function it_can_add_a_new_translation_to_an_existing_translation_group()
     {
-        $this->translation->addGroupTranslation('en', 'test.test', 'Testing');
+        $this->translation->addGroupTranslation('en', 'test', 'test', 'Testing');
 
         $translations = $this->translation->allTranslationsFor('en');
 
@@ -144,7 +144,7 @@ class FileDriverTest extends TestCase
     /** @test */
     public function it_can_merge_a_language_with_the_base_language()
     {
-        $this->translation->addGroupTranslation('es', 'test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'test', 'hello', 'Hola!');
         $translations = $this->translation->getSourceLanguageTranslationsWith('es');
 
         $this->assertEquals($translations->toArray(), [
@@ -174,7 +174,7 @@ class FileDriverTest extends TestCase
     /** @test */
     public function it_can_add_a_vendor_namespaced_translations()
     {
-        $this->translation->addGroupTranslation('es', 'translation_test::test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'hello', 'Hola!');
 
         $this->assertEquals($this->translation->allTranslationsFor('es')->toArray(), [
             'group' => [
@@ -191,8 +191,8 @@ class FileDriverTest extends TestCase
     /** @test */
     public function it_can_merge_a_namespaced_language_with_the_base_language()
     {
-        $this->translation->addGroupTranslation('en', 'translation_test::test.hello', 'Hello');
-        $this->translation->addGroupTranslation('es', 'translation_test::test.hello', 'Hola!');
+        $this->translation->addGroupTranslation('en', 'translation_test::test', 'hello', 'Hello');
+        $this->translation->addGroupTranslation('es', 'translation_test::test', 'hello', 'Hola!');
         $translations = $this->translation->getSourceLanguageTranslationsWith('es');
 
         $this->assertEquals($translations->toArray(), [


### PR DESCRIPTION
Added multidimentional array support using Arr::dot helper. No changes needed on the UI, it will correctly show and save the keys in dotted style.
Changed addGroupTranslation signature to include the group detached from the key. It suits better for the function name, and we don't have to merge the group name with the key in all the calls and then explode the value again.