### PR TITLE
Feature: Ability to configure a DB connection for translations

### DIFF
--- a/config/translation.php
+++ b/config/translation.php
@@ -67,6 +67,9 @@ return [
     |
     */
     'database' => [
+
+        'connection' => '',
+
         'languages_table' => 'languages',
 
         'translations_table' => 'translations',

--- a/database/migrations/2018_08_29_200844_create_languages_table.php
+++ b/database/migrations/2018_08_29_200844_create_languages_table.php
@@ -14,12 +14,13 @@ class CreateLanguagesTable extends Migration
      */
     public function up()
     {
-        Schema::create(config('translation.database.languages_table'), function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name')->nullable();
-            $table->string('language');
-            $table->timestamps();
-        });
+        Schema::connection(config('translation.database.connection'))
+            ->create(config('translation.database.languages_table'), function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name')->nullable();
+                $table->string('language');
+                $table->timestamps();
+            });
 
         Language::create([
             'language' => config('app.locale'),
@@ -33,6 +34,7 @@ class CreateLanguagesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists(config('translation.database.languages_table'));
+        Schema::connection(config('translation.database.connection'))
+            ->dropIfExists(config('translation.database.languages_table'));
     }
 }

--- a/database/migrations/2018_08_29_205156_create_translations_table.php
+++ b/database/migrations/2018_08_29_205156_create_translations_table.php
@@ -13,15 +13,17 @@ class CreateTranslationsTable extends Migration
      */
     public function up()
     {
-        Schema::create(config('translation.database.translations_table'), function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('language_id');
-            $table->foreign('language_id')->references('id')->on(config('translation.database.languages_table'));
-            $table->string('group')->nullable();
-            $table->text('key');
-            $table->text('value')->nullable();
-            $table->timestamps();
-        });
+        Schema::connection(config('translation.database.connection'))
+            ->create(config('translation.database.translations_table'), function (Blueprint $table) {
+                $table->increments('id');
+                $table->unsignedInteger('language_id');
+                $table->foreign('language_id')->references('id')
+                    ->on(config('translation.database.languages_table'));
+                $table->string('group')->nullable();
+                $table->text('key');
+                $table->text('value')->nullable();
+                $table->timestamps();
+            });
     }
 
     /**
@@ -31,6 +33,7 @@ class CreateTranslationsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists(config('translation.database.translations_table'));
+        Schema::connection(config('translation.database.connection'))
+            ->dropIfExists(config('translation.database.translations_table'));
     }
 }

--- a/src/Language.php
+++ b/src/Language.php
@@ -11,6 +11,7 @@ class Language extends Model
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
+        $this->connection= config('translation.database.connection');
         $this->table = config('translation.database.languages_table');
     }
 

--- a/src/Language.php
+++ b/src/Language.php
@@ -11,7 +11,7 @@ class Language extends Model
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
-        $this->connection= config('translation.database.connection');
+        $this->connection = config('translation.database.connection');
         $this->table = config('translation.database.languages_table');
     }
 

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -11,7 +11,7 @@ class Translation extends Model
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
-        $this->connection= config('translation.database.connection');
+        $this->connection = config('translation.database.connection');
         $this->table = config('translation.database.translations_table');
     }
 

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -11,6 +11,7 @@ class Translation extends Model
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
+        $this->connection= config('translation.database.connection');
         $this->table = config('translation.database.translations_table');
     }
 


### PR DESCRIPTION
with this PR, it is possible to configure a separate data source for managing the translations. That way you can have a team working on translations via UI (e.g. Nova) and share the translations across different instances (e.g. development & staging).

- add translation.database.connection key (default is empty)
- updated models and migrations to take connection key into account