### PR TITLE
change access to public for update bulk translation within single group

### DIFF
--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -254,7 +254,7 @@ class File extends Translation implements DriverInterface
      * @param array $translations
      * @return void
      */
-    private function saveGroupTranslations($language, $group, $translations)
+    public function saveGroupTranslations($language, $group, $translations)
     {
         // here we check if it's a namespaced translation which need saving to a
         // different path


### PR DESCRIPTION
To update list of transaction individually takes lots of activity.

for reduce update file occurrence, I stored all group translation inside database so after on one click each group transaction ´write inside file.

further usage example as below, user can add new methods inside LanguageTranslationController
```
public function updateToFile()
 {
//To Find updated languages
        $languages = $this->languageTranslateRepository->getDistictLanguages();

        foreach ($languages as $language) {
            //get all translation of the language
            $translations = $this->translation->getGroupTranslationsFor($language);

            $from_database = $this->languageTranslateRepository->all($language);

            foreach ($from_database as $key => $val) {
                $group = $val->lang_group;
                // does the group exist? If not, create it.
                if (!$translations->keys()->contains($group)) {
                    $translations->put($group, collect());
                }
                $values = $translations->get($group);
                $values[$val->lang_key] = $val->lang_val;
                $translations->put($group, collect($values));
            }
            $this->translation->saveGroupTranslations($language, $group, $translations->get($group));
        }
    }
```