### PR TITLE
Add toBase() before merge in order to avoid exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /node_modules
 .phpunit.result.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "joedixon/laravel-translation",
+    "name": "bojan121/laravel-translation",
     "description": "A tool for managing all of your Laravel translations",
     "type": "library",
     "license": "MIT",

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -170,7 +170,7 @@ class Database extends Translation implements DriverInterface
             return $translations->mapWithKeys(function ($translation) {
                 return [$translation->key => $translation->value];
             });
-        });
+        })->collapse();
     }
 
     /**

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -61,11 +61,14 @@ abstract class Translation
 
         return $sourceTranslations->map(function ($groups, $type) use ($language, $languageTranslations) {
             return $groups->map(function ($translations, $group) use ($type, $language, $languageTranslations) {
-                $translations = $translations->toArray();
+
+                $translations = collect($translations)->toArray();
+
                 array_walk($translations, function (&$value, &$key) use ($type, $group, $language, $languageTranslations) {
+                    $arrayOrValue = $languageTranslations->get($type, collect())->get($group, collect());
                     $value = [
                         $this->sourceLanguage => $value,
-                        $language => $languageTranslations->get($type, collect())->get($group, collect())->get($key),
+                        $language => is_string($arrayOrValue) ? $arrayOrValue : $arrayOrValue->get($key),
                     ];
                 });
 

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -2,10 +2,10 @@
 
 namespace JoeDixon\Translation\Http\Controllers;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use JoeDixon\Translation\Drivers\Translation;
 use JoeDixon\Translation\Http\Requests\TranslationRequest;
 

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -26,7 +26,7 @@ class LanguageTranslationController extends Controller
         }
 
         $languages = $this->translation->allLanguages();
-        $groups = $this->translation->getGroupsFor(config('app.locale'))->merge('single');
+        $groups = $this->translation->getGroupsFor(config('app.locale'))->toBase()->merge('single');
         $translations = $this->translation->filterTranslationsFor($language, $request->get('filter'));
 
         if ($request->has('group') && $request->get('group')) {


### PR DESCRIPTION
Laravel 6.6, if you add new language via the web interface, it throws an exception if you try to access the translations for any language.
This is a well known behavior, see: https://github.com/laravel/framework/issues/22626 
Also see this related comment from Mohamed Said: https://github.com/laravel/framework/issues/19784#issuecomment-311634622

And indeed, adding toBase() just before merging fixes the problem.