### PR TITLE
Allow save translation to subfolders

### DIFF
--- a/config/translation.php
+++ b/config/translation.php
@@ -53,7 +53,7 @@ return [
     | UI URL
     |--------------------------------------------------------------------------
     |
-    | Define the URL used to access the language management too.
+    | Define the URL used to access the language management tool.
     |
     */
     'ui_url' => 'languages',

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,12 @@
 <?php
 
-Route::group(config('translation.route_group_config') + ['namespace' => 'JoeDixon\\Translation\\Http\\Controllers'], function ($router) {
+$routesDefaultFormat = config('translation.route_group_config');
+
+if(is_callable($routesDefaultFormat)){
+    $routesDefaultFormat = $routesDefaultFormat();
+}
+
+Route::group($routesDefaultFormat + ['namespace' => 'JoeDixon\\Translation\\Http\\Controllers'], function ($router) {
     $router->get(config('translation.ui_url'), 'LanguageController@index')
         ->name('languages.index');
 

--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -269,16 +269,15 @@ class File extends Translation implements DriverInterface
 
         $groupName = '';
         $groupPath = '';
-        $pathArray = explode( DIRECTORY_SEPARATOR , $group);
-        foreach($pathArray as $key => $value){
-            if( $key == (count($pathArray)-1) ){
+        $pathArray = explode(DIRECTORY_SEPARATOR, $group);
+        foreach ($pathArray as $key => $value) {
+            if ($key == (count($pathArray) - 1)) {
                 $groupName = $value;
-            }
-            else{
+            } else {
                 $groupPath .= $value.DIRECTORY_SEPARATOR;
             }
         }
-        
+
         $directory = "{$this->languageFilesPath}".DIRECTORY_SEPARATOR."{$language}".DIRECTORY_SEPARATOR."{$groupPath}";
 
         if (! $this->disk->exists($directory)) {
@@ -302,16 +301,15 @@ class File extends Translation implements DriverInterface
 
         $groupName = '';
         $groupPath = '';
-        $pathArray = explode( DIRECTORY_SEPARATOR , $group);
-        foreach($pathArray as $key => $value){
-            if( $key == (count($pathArray)-1) ){
+        $pathArray = explode(DIRECTORY_SEPARATOR, $group);
+        foreach ($pathArray as $key => $value) {
+            if ($key == (count($pathArray) - 1)) {
                 $groupName = $value;
-            }
-            else{
+            } else {
                 $groupPath .= $value.DIRECTORY_SEPARATOR;
             }
         }
-        
+
         $directory = "{$this->languageFilesPath}".DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR."{$namespace}".DIRECTORY_SEPARATOR."{$language}".DIRECTORY_SEPARATOR."{$groupPath}";
 
         if (! $this->disk->exists($directory)) {
@@ -370,7 +368,7 @@ class File extends Translation implements DriverInterface
                 $vendor = Str::before(Str::after($file->getPathname(), 'vendor'.DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR);
                 return "{$vendor}::{$nameWithPath}";
             }
-            
+
             return str_replace('.php', '', $nameWithPath);
         });
     }

--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -366,6 +366,7 @@ class File extends Translation implements DriverInterface
             $nameWithPath = str_replace('.php', '', explode(DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR, $file->getPathname())[1]);
             if (Str::contains($file->getPathname(), 'vendor')) {
                 $vendor = Str::before(Str::after($file->getPathname(), 'vendor'.DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR);
+
                 return "{$vendor}::{$nameWithPath}";
             }
 


### PR DESCRIPTION
If we translate something from "en_US/foo/bar/baz.php" to pt-BR, it was being saved at "pt_BR/baz.php".
That change corrects it.

Me and other users are having this issue. #110 