### PR TITLE
Disable migrations when file driver is being used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "joedixon/laravel-translation",
+    "name": "alex-arabadjiev/laravel-translation",
     "description": "A tool for managing all of your Laravel translations",
     "type": "library",
     "license": "MIT",

--- a/config/translation.php
+++ b/config/translation.php
@@ -68,7 +68,6 @@ return [
     */
     'database' => [
 
-        // Leave empty to disable migrations
         'connection' => '',
 
         'languages_table' => 'languages',

--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -265,7 +265,20 @@ class File extends Translation implements DriverInterface
         if (Str::contains($group, '::')) {
             return $this->saveNamespacedGroupTranslations($language, $group, $translations);
         }
-        $this->disk->put("{$this->languageFilesPath}".DIRECTORY_SEPARATOR."{$language}".DIRECTORY_SEPARATOR."{$group}.php", "<?php\n\nreturn ".var_export($translations, true).';'.\PHP_EOL);
+        $this->disk->put("{$this->languageFilesPath}".DIRECTORY_SEPARATOR."{$language}".DIRECTORY_SEPARATOR."{$group}.php", "<?php\n\nreturn ".$this->varexport($translations, true).';'.\PHP_EOL);
+    }
+
+    // https://www.php.net/manual/en/function.var-export.php#124194
+    private function varexport($expression, $return=FALSE) {
+        $export = var_export($expression, TRUE);
+        $patterns = [
+            "/array \(/" => '[',
+            "/^([ ]*)\)(,?)$/m" => '$1$1]$2',
+            "/=>[ ]?\n[ ]+\[/" => '=> [',
+            "/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$1$2 => $3',
+        ];
+        $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
+        if ((bool)$return) return $export; else echo $export;
     }
 
     /**

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -115,8 +115,7 @@ class TranslationServiceProvider extends ServiceProvider
      */
     private function loadMigrations()
     {
-        // Don't migrate if file driver is being used
-        if (config('translation.driver') === 'file') {
+        if (!config('translation.database.connection')) {
             return;
         }
 

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -116,7 +116,7 @@ class TranslationServiceProvider extends ServiceProvider
     private function loadMigrations()
     {
         // Don't migrate if no database connection is given
-        if (!config('translation.database.connection')) {
+        if (! config('translation.database.connection')) {
             return;
         }
 

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -115,8 +115,8 @@ class TranslationServiceProvider extends ServiceProvider
      */
     private function loadMigrations()
     {
-        // Don't migrate if no database connection is given
-        if (! config('translation.database.connection')) {
+        // Don't migrate if file driver is being used
+        if (config('translation.driver') === 'file') {
             return;
         }
 


### PR DESCRIPTION
This package always creates two migrations, even when they are not needed. In this PR, we check whether the file driver is being used in the config and don't load the migrations if it is. If the database driver is used, everything proceeds as before.