### PR TITLE
loadMigrationsFrom only when driver is database

### DIFF
--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -93,7 +93,9 @@ class TranslationServiceProvider extends ServiceProvider
      */
     private function mergeConfiguration()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/translation.php', 'translation');
+        if (config('translation.driver') == 'database') {
+            $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        }
     }
 
     /**


### PR DESCRIPTION
when we have a migration of the same name:

`Cannot declare class CreateLanguagesTable, because the name is already in use`
