### PR TITLE
Auto populate group field on create if group was already selected in a language index page

### DIFF
--- a/resources/views/forms/text.blade.php
+++ b/resources/views/forms/text.blade.php
@@ -8,7 +8,7 @@
         id="{{ $field }}" 
         type="text" 
         placeholder="{{ isset($placeholder) ? $placeholder : '' }}"
-        value="{{ old($field) }}"
+        value="{{ $value ?? old($field) }}"
         {{ isset($required) ? 'required' : '' }}>
     @if($errors->has($field))
         @foreach($errors->get($field) as $error)

--- a/resources/views/languages/translations/create.blade.php
+++ b/resources/views/languages/translations/create.blade.php
@@ -18,7 +18,7 @@
 
                 <div class="panel-body p-4">
 
-                    @include('translation::forms.text', ['field' => 'group', 'label' => __('translation::translation.group_label'), 'placeholder' => __('translation::translation.group_placeholder')])
+                    @include('translation::forms.text', ['field' => 'group', 'value' => request()->has("group") ? request()->group : "", 'label' => __('translation::translation.group_label'), 'placeholder' => __('translation::translation.group_placeholder')])
                     
                     @include('translation::forms.text', ['field' => 'key', 'label' => __('translation::translation.key_label'), 'placeholder' => __('translation::translation.key_placeholder')])
 

--- a/resources/views/languages/translations/index.blade.php
+++ b/resources/views/languages/translations/index.blade.php
@@ -20,7 +20,7 @@
 
                     @include('translation::forms.select', ['name' => 'group', 'items' => $groups, 'submit' => true, 'selected' => Request::get('group'), 'optional' => true])
                     
-                    <a href="{{ route('languages.translations.create', $language) }}" class="button">
+                    <a id="create-button" href="{{ route('languages.translations.create', $language) }}" class="button">
                         {{ __('translation::translation.add') }}
                     </a>
                 
@@ -86,4 +86,15 @@
 
     </form>
 
+@endsection
+
+@section('scripts')
+    <script>
+        const createBtn = document.querySelector("#create-button");
+        const selectMenu= document.querySelector("[name=group]");
+        const selectedLang = selectMenu.value;
+        let link = "{{  route('languages.translations.create', $language)  }}";
+        link = link + (selectedLang ? `?group=${selectedLang}` : "")
+        createBtn.setAttribute("href", link);
+    </script>
 @endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -20,5 +20,6 @@
     </div>
     
     <script src="{{ asset('/vendor/translation/js/app.js') }}"></script>
+    @yield('scripts')
 </body>
 </html>


### PR DESCRIPTION
For better user experience I think it's better if we auto-populate the group field on create page from the index page if it was selected.

This is to save the user the struggle of going back to the index page to see the group name and also to avoid misspelling it.