### PR TITLE
Database: cache group translations

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -13,6 +13,8 @@ class Database extends Translation implements DriverInterface
 
     protected $scanner;
 
+    protected array $groupTranslationCache = [];
+
     public function __construct($sourceLanguage, $scanner)
     {
         $this->sourceLanguage = $sourceLanguage;
@@ -181,18 +183,32 @@ class Database extends Translation implements DriverInterface
      */
     public function getGroupTranslationsFor($language)
     {
-        $translations = $this->getLanguage($language)
+        if (isset($this->groupTranslationCache[$language])) {
+            return $this->groupTranslationCache[$language];
+        }
+
+        $languageModel = $this->getLanguage($language);
+
+        if (is_null($languageModel)) {
+            return collect();
+        }
+
+        $translations = $languageModel
             ->translations()
             ->whereNotNull('group')
             ->where('group', 'not like', '%single')
             ->get()
             ->groupBy('group');
 
-        return $translations->map(function ($translations) {
+        $result = $translations->map(function ($translations) {
             return $translations->mapWithKeys(function ($translation) {
                 return [$translation->key => $translation->value];
             });
         });
+
+        $this->groupTranslationCache[$language] = $result;
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This applies the same caching mechanism that I used in #242 for caching languages to caching group translations. This is one of the things that I did in my private clone to prevent duplicate requests.