### PR TITLE
Database: return empty collection when language does not exist on get…

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -155,7 +155,13 @@ class Database extends Translation implements DriverInterface
      */
     public function getSingleTranslationsFor($language)
     {
-        $translations = $this->getLanguage($language)
+        $languageModel = $this->getLanguage($language);
+
+        if (is_null($languageModel)) {
+            return collect();
+        }
+
+        $translations = $languageModel
             ->translations()
             ->where('group', 'like', '%single')
             ->orWhereNull('group')


### PR DESCRIPTION
Database: return empty collection when language does not exist on getSingleTranslationsFor a given language, to avoid operation on null.

Among other things, this avoids errors through third-party packages that call translations during artisan migrate and _before_ the actual laravel-translation migrations have run - else we experience a fatal error that effectively prevents migration and causes all kinds of trouble on automated deployment systems.

This particular error came to light when attempting to set the driver to database on an existing Laravel project that included `rinvex/countries` and then running migrations.