### PR TITLE
Auto translate using Translation Engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^8.0||^9.0||^10.0",
-        "laravel/legacy-factories": "^1.3"
+        "laravel/legacy-factories": "^1.3",
+        "stichoza/google-translate-php": "^4.1"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^8.0",

--- a/readme.md
+++ b/readme.md
@@ -211,4 +211,4 @@ run for all languages or a single language.
 
 It will then translate all the tokens using Google Translate for FREE!
 
-You can edit these the auto translated texts using the [User interface](#Userinterface) 
+You can edit these the auto translated texts using the [User interface](#user-interface) 

--- a/readme.md
+++ b/readme.md
@@ -209,3 +209,6 @@ This command will scan your project (using the paths supplied in the
 configuration file) and create all of the missing translation keys. This can be
 run for all languages or a single language.
 
+It will then translate all the tokens using Google Translate for FREE!
+
+You can edit these the auto translated texts using the [User interface](#User interface) 

--- a/readme.md
+++ b/readme.md
@@ -211,4 +211,4 @@ run for all languages or a single language.
 
 It will then translate all the tokens using Google Translate for FREE!
 
-You can edit these the auto translated texts using the [User interface](#User interface) 
+You can edit these the auto translated texts using the [User interface](#Userinterface) 

--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ run for all languages or a single language.
 ### Automated Translation Using [Stichoza Google Translate Package](https://github.com/Stichoza/google-translate-php)   
 
 ```
-translation:translation:auto-translate
+translation:auto-translate
 ```
 This command will scan your project (using the paths supplied in the
 configuration file) and create all of the missing translation keys. This can be

--- a/readme.md
+++ b/readme.md
@@ -199,3 +199,13 @@ This command will scan your project (using the paths supplied in the
 configuration file) and create all of the missing translation keys. This can be
 run for all languages or a single language.
 
+
+### Automated Translation Using [Stichoza Google Translate Package](https://github.com/Stichoza/google-translate-php)   
+
+```
+translation:translation:auto-translate
+```
+This command will scan your project (using the paths supplied in the
+configuration file) and create all of the missing translation keys. This can be
+run for all languages or a single language.
+

--- a/resources/lang/en/translation.php
+++ b/resources/lang/en/translation.php
@@ -17,6 +17,7 @@ return [
     'language_key_added' => 'New language key added successfully 👏',
     'no_missing_keys' => 'There are no missing translation keys in the app 🎉',
     'keys_synced' => 'Missing keys synchronised successfully 🎊',
+    'auto_translated' => 'Automated Translation completed successfully 🎊',
     'search' => 'Search all translations',
     'translations' => 'Translation',
     'language_name' => 'Name',

--- a/src/Console/Commands/AutoTranslateKeysCommand.php
+++ b/src/Console/Commands/AutoTranslateKeysCommand.php
@@ -23,7 +23,7 @@ class AutoTranslateKeysCommand extends BaseCommand
      *
      * @var string
      */
-    protected $description = 'Auto translate key using google translate';
+    protected $description = 'Auto translate keys using google translate';
 
     /**
      * Execute the console command.

--- a/src/Console/Commands/AutoTranslateKeysCommand.php
+++ b/src/Console/Commands/AutoTranslateKeysCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace JoeDixon\Translation\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use JoeDixon\Translation\Drivers\Database;
+use JoeDixon\Translation\Drivers\File;
+use JoeDixon\Translation\Drivers\Translation;
+use JoeDixon\Translation\Scanner;
+
+class AutoTranslateKeysCommand extends BaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'translation:auto-translate {language?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Auto translate key using google translate';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $language = $this->argument('language') ?: false;
+        try {
+            // if we have a language, pass it in, if not the method will
+            // automagically translate all languages
+            $this->translation->autoTranslate($language);
+
+            return $this->info(__('translation::translation.auto_translated'));
+        } catch (\Exception $e) {
+            return $this->error($e->getMessage());
+        }
+        
+        
+    }
+}

--- a/src/Console/Commands/AutoTranslateKeysCommand.php
+++ b/src/Console/Commands/AutoTranslateKeysCommand.php
@@ -3,11 +3,6 @@
 namespace JoeDixon\Translation\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
-use JoeDixon\Translation\Drivers\Database;
-use JoeDixon\Translation\Drivers\File;
-use JoeDixon\Translation\Drivers\Translation;
-use JoeDixon\Translation\Scanner;
 
 class AutoTranslateKeysCommand extends BaseCommand
 {

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -89,6 +89,11 @@ abstract class Translation
      * @param $language
      */
     public function translateLanguage($language){
+        //No need to translate e.g. English to English
+        if ($language === $this->sourceLanguage) {
+            return;
+        }
+
         $translations = $this->getSourceLanguageTranslationsWith($language);
 
         foreach ($translations as $type => $groups) {

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -70,6 +70,7 @@ abstract class Translation
     }
 
     /**
+     *
      * Translate text using Google Translate
      *
      * @param $language

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -70,7 +70,6 @@ abstract class Translation
     }
 
     /**
-     *
      * Translate text using Google Translate
      *
      * @param $language
@@ -79,7 +78,7 @@ abstract class Translation
      * @throws \ErrorException
      */
     public function getGoogleTranslate($language,$token){
-        $tr = new GoogleTranslate($language);
+        $tr = new GoogleTranslate($language, $this->sourceLanguage);
         return $tr->translate($token);
     }
 

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -98,7 +98,9 @@ abstract class Translation
         foreach ($translations as $type => $groups) {
             foreach ($groups as $group => $translations) {
                 foreach ($translations as $key => $value) {
-                    $sourceLanguageValue = $value[$this->sourceLanguage];
+                    //Value will be empty if it's found in the app source code but not in the source language files
+                    //We fall back to $key in that case
+                    $sourceLanguageValue = in_array($value[$this->sourceLanguage], ["", null]) ? $key : $value[$this->sourceLanguage];
                     $targetLanguageValue = $value[$language];
 
                     if (in_array($targetLanguageValue, ["", null])) {

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -78,7 +78,7 @@ abstract class Translation
      * @throws \ErrorException
      */
     public function getGoogleTranslate($language,$token){
-        $tr = new GoogleTranslate($language, $this->sourceLanguage);
+        $tr = new GoogleTranslate($language);
         return $tr->translate($token);
     }
 

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -99,8 +99,6 @@ abstract class Translation
         foreach ($translations as $type => $groups) {
             foreach ($groups as $group => $translations) {
                 foreach ($translations as $key => $value) {
-                    //Value will be empty if it's found in the app source code but not in the source language files
-                    //We fall back to $key in that case
                     $sourceLanguageValue = in_array($value[$this->sourceLanguage], ["", null]) ? $key : $value[$this->sourceLanguage];
                     $targetLanguageValue = $value[$language];
 

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -53,7 +53,8 @@ abstract class Translation
     }
 
     /**
-     * Translate all the token into it's respective language.
+     * Save all of the translations in the app without translation for a given language then
+     * Translate all the tokens into it's respective language using google translate
      *
      * @param  string  $language
      * @return void

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -70,9 +70,9 @@ abstract class Translation
     }
 
     /**
-     * 
+     *
      * Translate text using Google Translate
-     * 
+     *
      * @param $language
      * @param $token
      * @return string|null
@@ -84,22 +84,25 @@ abstract class Translation
     }
 
     /**
-     * 
-     * Loop through all the keys and get translated text from google 
-     * 
+     * Loop through all the keys and get translated text from Google Translate
+     *
      * @param $language
      */
     public function translateLanguage($language){
-        $translations = $this->allTranslationsFor($language);
+        $translations = $this->getSourceLanguageTranslationsWith($language);
+
         foreach ($translations as $type => $groups) {
             foreach ($groups as $group => $translations) {
                 foreach ($translations as $key => $value) {
-                    if (in_array($value,["",null])){
-                        $new_value=$this->getGoogleTranslate($language,$key);
+                    $sourceLanguageValue = $value[$this->sourceLanguage];
+                    $targetLanguageValue = $value[$language];
+
+                    if (in_array($targetLanguageValue, ["", null])) {
+                        $new_value = $this->getGoogleTranslate($language, $sourceLanguageValue);
                         if (Str::contains($group, 'single')) {
-                            $this->addSingleTranslation($language, $group, $key,$new_value);
+                            $this->addSingleTranslation($language, $group, $key, $new_value);
                         } else {
-                            $this->addGroupTranslation($language, $group, $key,$new_value);
+                            $this->addGroupTranslation($language, $group, $key, $new_value);
                         }
                     }
 
@@ -107,7 +110,6 @@ abstract class Translation
             }
         }
     }
-    
 
     /**
      * Get all translations for a given language merged with the source language.

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -53,7 +53,7 @@ abstract class Translation
     }
 
     /**
-     * Save all of the translations in the app without translation for a given language.
+     * Translate all the token into it's respective language.
      *
      * @param  string  $language
      * @return void
@@ -68,11 +68,26 @@ abstract class Translation
         }
     }
 
+    /**
+     * 
+     * Translate text using Google Translate
+     * 
+     * @param $language
+     * @param $token
+     * @return string|null
+     * @throws \ErrorException
+     */
     public function getGoogleTranslate($language,$token){
         $tr = new GoogleTranslate($language);
         return $tr->translate($token);
     }
-    
+
+    /**
+     * 
+     * Loop through all the keys and get translated text from google 
+     * 
+     * @param $language
+     */
     public function translateLanguage($language){
         $translations = $this->allTranslationsFor($language);
         foreach ($translations as $type => $groups) {

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use JoeDixon\Translation\Console\Commands\AddLanguageCommand;
 use JoeDixon\Translation\Console\Commands\AddTranslationKeyCommand;
+use JoeDixon\Translation\Console\Commands\AutoTranslateKeysCommand;
 use JoeDixon\Translation\Console\Commands\ListLanguagesCommand;
 use JoeDixon\Translation\Console\Commands\ListMissingTranslationKeys;
 use JoeDixon\Translation\Console\Commands\SynchroniseMissingTranslationKeys;
@@ -151,6 +152,7 @@ class TranslationServiceProvider extends ServiceProvider
                 ListMissingTranslationKeys::class,
                 SynchroniseMissingTranslationKeys::class,
                 SynchroniseTranslationsCommand::class,
+                AutoTranslateKeysCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
translation:auto-translate
This command will scan your project (using the paths supplied in the configuration file) and create all of the missing translation keys. This can be run for all languages or a single language.

It will then translate all the tokens using Google Translate for FREE!

You can edit these auto translated texts using the [User interface](https://github.com/timoye/laravel-translation/tree/auto-translate#user-interface)