### PR TITLE
app locale variable issue fixed in Translation Driver

### DIFF
--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -59,7 +59,7 @@ abstract class Translation
      */
     public function getSourceLanguageTranslationsWith($language)
     {
-        $sourceTranslations = $this->allTranslationsFor($this->sourceLanguage);
+        $sourceTranslations = $this->allTranslationsFor(app()->config['app']['locale']);
         $languageTranslations = $this->allTranslationsFor($language);
 
         return $sourceTranslations->map(function ($groups, $type) use ($language, $languageTranslations) {
@@ -67,7 +67,7 @@ abstract class Translation
                 $translations = $translations->toArray();
                 array_walk($translations, function (&$value, $key) use ($type, $group, $language, $languageTranslations) {
                     $value = [
-                        $this->sourceLanguage => $value,
+                        app()->config['app']['locale'] => $value,
                         $language => $languageTranslations->get($type, collect())->get($group, collect())->get($key),
                     ];
                 });
@@ -94,7 +94,7 @@ abstract class Translation
         return $allTranslations->map(function ($groups, $type) use ($language, $filter) {
             return $groups->map(function ($keys, $group) use ($language, $filter) {
                 return collect($keys)->filter(function ($translations, $key) use ($group, $language, $filter) {
-                    return strs_contain([$group, $key, $translations[$language], $translations[$this->sourceLanguage]], $filter);
+                    return strs_contain([$group, $key, $translations[$language], $translations[app()->config['app']['locale']]], $filter);
                 });
             })->filter(function ($keys) {
                 return $keys->isNotEmpty();


### PR DESCRIPTION
I have faced out an issue on translation driver about your $sourceLanguage property, this variable has set on binding Translation::class, so when app::locale variable changes, $sourceLanguage keeps same. Thus, I propose that you can use one of app()->getLocale() or App::getLocale(), because I change this app locale variable on a middleware. Your translation view (translation/languages/translations/index.blade.php) occurs an error because of changing app->locale. At now, sourceLanguage property has assigned in vain. You can remove this assignments after checking it out.