### PR TITLE
Use code blocks in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,15 @@ Below are a full list of features:
 
 Install the package via Composer
 
-`composer require joedixon/laravel-translation`
+```shell
+composer require joedixon/laravel-translation
+```
 
 Publish configuration and assets
 
-`php artisan vendor:publish --provider="JoeDixon\Translation\TranslationServiceProvider"`
+```shell
+php artisan vendor:publish --provider="JoeDixon\Translation\TranslationServiceProvider"
+```
 
 The service provider is loaded automatically using [package discovery](https://laravel.com/docs/5.7/packages#package-discovery).
 


### PR DESCRIPTION
Using good blocks in readme.md to make it easier to copy the command using GitHub copy button.