### PR TITLE
Decode PHP strings to prevent slashes in output

### DIFF
--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -48,6 +48,8 @@ class Scanner
         foreach ($this->disk->allFiles($this->scanPaths) as $file) {
             if (preg_match_all("/$matchingPattern/siU", $file->getContents(), $matches)) {
                 foreach ($matches[2] as $key) {
+                    // Decode php strings, so in the final JSON e.g. __('Don\'t') becomes "Don't" instead of "Don\\'t"
+                    $key = stripcslashes($key);
                     if (preg_match("/(^[a-zA-Z0-9:_-]+([.][^\1)\ ]+)+$)/siU", $key, $arrayMatches)) {
                         [$file, $k] = explode('.', $arrayMatches[0], 2);
                         $results['group'][$file][$k] = '';

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -31,7 +31,7 @@ class ScannerTest extends TestCase
         $this->scanner = app()->make(Scanner::class);
         $matches = $this->scanner->findTranslations();
 
-        $this->assertEquals($matches, ['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]]);
+        $this->assertEquals($matches, ['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'This will go in the JSON array, and it\'ll properly unescape the apostrophe.' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]]);
         $this->assertCount(2, $matches);
     }
 }

--- a/tests/fixtures/scan-tests/__.txt
+++ b/tests/fixtures/scan-tests/__.txt
@@ -4,3 +4,5 @@ __('This will go in the JSON array')
 __(
     'This will also go in the JSON array'
 )
+
+__('This will go in the JSON array, and it\'ll properly unescape the apostrophe.')


### PR DESCRIPTION
Decode PHP strings, so in the final JSON e.g. `__('Don\'t')` becomes `"Don't"` instead of `"Don\\'t"`

# Steps to reproduce:

## Blade file
````blade
({{ __('This is a text with an apostrophe in it; let\'s add it to my translations file!') }})
````

## Run `php artisan translation:sync-missing-translation-keys`

## How laravel-translation stores it in `<language>.json` after running that:

````json
"This is a text with an apostrophe in it; let\\'s add it to my translations file!": "",
````

## What it should be storing:

````json
"This is a text with an apostrophe in it; let's add it to my translations file!": "",
````