### PR TITLE
File scanner: Ignore escaped quotes when detecting end of string (`\'`)

### DIFF
--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -41,7 +41,7 @@ class Scanner
             '('. // Start a new group to match:
             '.+'. // Must start with group
             ')'. // Close group
-            "[\'\"]". // Closing quote
+            "(?<!\\\\)[\'\"]". // Closing quote (don't match if escaped with backslash)
             "\s*". // Whitespace after param
             "[\),]";  // Close parentheses or new parameter
 

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -31,7 +31,7 @@ class ScannerTest extends TestCase
         $this->scanner = app()->make(Scanner::class);
         $matches = $this->scanner->findTranslations();
 
-        $this->assertEquals($matches, ['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]]);
+        $this->assertEquals(['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]], $matches);
         $this->assertCount(2, $matches);
     }
 }

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -31,7 +31,7 @@ class ScannerTest extends TestCase
         $this->scanner = app()->make(Scanner::class);
         $matches = $this->scanner->findTranslations();
 
-        $this->assertEquals(['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]], $matches);
+        $this->assertEquals(['single' => ['single' => ['This will go in the JSON array' => '', 'This will also go in the JSON array' => '', 'The first half of this sentence should go into the \'JSON array\', but the second part should as well!' => '', 'trans' => '']], 'group' => ['lang' => ['first_match' => ''], 'lang_get' => ['first' => '', 'second' => ''], 'trans' => ['first_match' => '', 'third_match' => ''], 'trans_choice' => ['with_params' => '']]], $matches);
         $this->assertCount(2, $matches);
     }
 }

--- a/tests/fixtures/scan-tests/__.txt
+++ b/tests/fixtures/scan-tests/__.txt
@@ -4,3 +4,7 @@ __('This will go in the JSON array')
 __(
     'This will also go in the JSON array'
 )
+
+__('This will go in the JSON array, and it\'ll properly unescape the apostrophe.')
+
+__('The first half of this sentence should go into the \'JSON array\', but the second part should as well!')


### PR DESCRIPTION
So, for `__('\'Hello\', World!')` it previously detected the string `'Hello\`; after this fix, it'll properly detect `'Hello', World!`

This happened for `\'` both when followed by a comma `,` or a closing parenthesis `)`.